### PR TITLE
CI: Fix create-release body parameter value

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          body: |
-            ${{ steps.create-release-notes.outputs.changelog }}
+          body: ${{ steps.create-release-notes.outputs.changelog }}
           draft: false
           prerelease: false


### PR DESCRIPTION
## Related Issue
<!-- close #{issue_number} -->

close #

## Why need ?

Release notes is not generated as expected because create-release actions body parameter is empty.

## ToDo

- [x] Fix create-release actions body parameter
